### PR TITLE
Security implementations with tfsec

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
     environment: production
 
     env:
+      TF_VAR_my_public_ip_address: ${ secrets.MY_PUBLIC_IP_ADDRESS }
       TF_VAR_ssh_public_key: ${{ secrets.SSH_PUBLIC_KEY }}
       ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
       ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   terraform:
@@ -15,7 +16,8 @@ jobs:
     environment: production
 
     env:
-      TF_VAR_my_public_ip_address: ${ secrets.MY_PUBLIC_IP_ADDRESS }
+      TFSEC_GITHUB_TOKEN: ${{ secrets.TFSEC_GITHUB_TOKEN }}
+      TF_VAR_my_public_ip_address: ${{ secrets.MY_PUBLIC_IP_ADDRESS }}
       TF_VAR_ssh_public_key: ${{ secrets.SSH_PUBLIC_KEY }}
       ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
       ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
@@ -41,6 +43,12 @@ jobs:
 
     - name: Terraform Format
       run: terraform fmt -check || true
+
+    - name: Run tfsec security scan
+      uses: aquasecurity/tfsec-pr-commenter-action@v1.2.0
+      with:
+        github_token: ${{ secrets.TFSEC_GITHUB_TOKEN }}
+        directory: .
 
     - name: Terraform Plan
       run: terraform plan -input=false -var "ssh_public_key=${{ secrets.SSH_PUBLIC_KEY }}" || true

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ git clone https://github.com/PrzemyslawSwierzewski/Tarot-Cloud---Azure-Infrastru
 cd Tarot-Cloud---Azure-Infrastructure-with-Terraform
 ```
 
-2. **Terraform Setup** — Install Terraform CLI and configure GitHub secrets:  
+2. **Terraform Setup** — Install Terraform CLI and configure GitHub secrets:
+- `PUBLIC_IP_ADDRESS` - Your public IP address. It will be used to restrict the Network Security Group so that only you can access the Linux machine
 - `TF_API_TOKEN` — Terraform Cloud API token  
 - `SSH_PUBLIC_KEY` — SSH key for VM access  
 - `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, `ARM_SUBSCRIPTION_ID`, `ARM_TENANT_ID` — Azure Service Principal credentials  

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ cd Tarot-Cloud---Azure-Infrastructure-with-Terraform
 ```
 
 2. **Terraform Setup** — Install Terraform CLI and configure GitHub secrets:
+- `TFSEC_GITHUB_TOKEN` - Your GITHUB_TOKEN. It will be passed to GitHub action for tfsec checks
 - `PUBLIC_IP_ADDRESS` - Your public IP address. It will be used to restrict the Network Security Group so that only you can access the Linux machine
 - `TF_API_TOKEN` — Terraform Cloud API token  
 - `SSH_PUBLIC_KEY` — SSH key for VM access  

--- a/main.tf
+++ b/main.tf
@@ -35,6 +35,7 @@ module "dev_security" {
   rg_location = local.rg_location
   subnets    = module.dev_networking.tarot_cloud_subnet_ids
   vnets = module.dev_networking.vnets
+  my_public_ip_address = var.my_public_ip_address
 
   depends_on = [module.dev_networking]
 }
@@ -75,6 +76,7 @@ module "prod_security" {
   rg_location = local.rg_location
   subnets    = module.prod_networking.tarot_cloud_subnet_ids
   vnets = module.prod_networking.vnets
+  my_public_ip_address = var.my_public_ip_address
 
   depends_on = [module.prod_networking]
 }

--- a/modules/dev/security/locals.tf
+++ b/modules/dev/security/locals.tf
@@ -1,4 +1,78 @@
 locals {
-    network_security_group_name = "tarot-cloud-nsg"
-    environment = "dev"
+  network_security_group_name = "tarot-cloud-nsg"
+  environment                 = "dev"
+  my_public_ip_address        = var.my_public_ip_address
+  security_rules = {
+    Inbound = {
+      Allow80port = {
+        name                       = "Allow80port"
+        priority                   = 100
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "80"
+        source_address_prefix      = "Internet"
+        destination_address_prefix = "*"
+      }
+      Allow443port = {
+        name                       = "Allow443port"
+        priority                   = 101
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "443"
+        source_address_prefix      = "Internet"
+        destination_address_prefix = "*"
+      }
+      Allow22port = {
+        name                       = "Allow22port"
+        priority                   = 102
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "22"
+        source_address_prefix      = var.my_public_ip_address
+        destination_address_prefix = "*"
+      }
+    }
+
+    Outbound = {
+      Allow443port = {
+        name                       = "Allow443"
+        priority                   = 100
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "*"
+        source_port_range          = "*"
+        destination_port_range     = "*"
+        source_address_prefix      = "*"
+        destination_address_prefix = "Internet"
+      }
+      Allow80port = {
+        name                       = "Allow80"
+        priority                   = 101
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "*"
+        source_port_range          = "*"
+        destination_port_range     = "*"
+        source_address_prefix      = "*"
+        destination_address_prefix = "Internet"
+      }
+      Allow_ssh_to_my_machine = {
+        name                       = "Allow_ssh_to_my_machine"
+        priority                   = 102
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "22"
+        source_address_prefix      = var.my_public_ip_address
+        destination_address_prefix = "*"
+      }
+    }
+  }
 }

--- a/modules/dev/security/main.tf
+++ b/modules/dev/security/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_network_security_group" "tarot_cloud_nsg" {
   resource_group_name = var.tarot_cloud_rg_name
 
   dynamic "security_rule" {
-    for_each = flatten([for group in var.security_rules : values(group)])
+    for_each = flatten([for group in local.security_rules : values(group)])
     content {
       name                       = security_rule.value.name
       priority                   = security_rule.value.priority

--- a/modules/dev/security/variables.tf
+++ b/modules/dev/security/variables.tf
@@ -7,76 +7,14 @@ variable "rg_location" {
 }
 
 variable "subnets" {
-  type = list(string)
+  type        = list(string)
   description = "Map of subnet IDs to attach NSGs"
-}
-
-variable "security_rules" {
-  type = map(map(object({
-    name                       = string
-    priority                   = number
-    direction                  = string
-    access                     = string
-    protocol                   = string
-    source_port_range          = string
-    destination_port_range     = string
-    source_address_prefix      = string
-    destination_address_prefix = string
-  })))
-
-  default = {
-    Inbound = {
-      Allow80port = {
-        name                       = "Allow80port"
-        priority                   = 100
-        direction                  = "Inbound"
-        access                     = "Allow"
-        protocol                   = "Tcp"
-        source_port_range          = "*"
-        destination_port_range     = "80"
-        source_address_prefix      = "*"
-        destination_address_prefix = "*"
-      }
-      Allow443port = {
-        name                       = "Allow443port"
-        priority                   = 101
-        direction                  = "Inbound"
-        access                     = "Allow"
-        protocol                   = "Tcp"
-        source_port_range          = "*"
-        destination_port_range     = "443"
-        source_address_prefix      = "*"
-        destination_address_prefix = "*"
-      }
-      Allow22port = {
-        name                       = "Allow22port"
-        priority                   = 102
-        direction                  = "Inbound"
-        access                     = "Allow"
-        protocol                   = "Tcp"
-        source_port_range          = "*"
-        destination_port_range     = "22"
-        source_address_prefix      = "*"
-        destination_address_prefix = "*"
-      }
-    }
-
-    Outbound = {
-      AllowAll = {
-        name                       = "AllowAll"
-        priority                   = 100
-        direction                  = "Outbound"
-        access                     = "Allow"
-        protocol                   = "*"
-        source_port_range          = "*"
-        destination_port_range     = "*"
-        source_address_prefix      = "*"
-        destination_address_prefix = "*"
-      }
-    }
-  }
 }
 
 variable "vnets" {
   type = list(string)
+}
+
+variable "my_public_ip_address" {
+  type = string
 }

--- a/modules/prod/security/locals.tf
+++ b/modules/prod/security/locals.tf
@@ -1,4 +1,78 @@
 locals {
-    network_security_group_name = "tarot-cloud-nsg"
-    environment          = "prod"
+  network_security_group_name = "tarot-cloud-nsg"
+  environment                 = "prod"
+  my_public_ip_address        = var.my_public_ip_address
+  security_rules = {
+    Inbound = {
+      Allow80port = {
+        name                       = "Allow80port"
+        priority                   = 100
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "80"
+        source_address_prefix      = "Internet"
+        destination_address_prefix = "*"
+      }
+      Allow443port = {
+        name                       = "Allow443port"
+        priority                   = 101
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "443"
+        source_address_prefix      = "Internet"
+        destination_address_prefix = "*"
+      }
+      Allow22port = {
+        name                       = "Allow22port"
+        priority                   = 102
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "22"
+        source_address_prefix      = var.my_public_ip_address
+        destination_address_prefix = "*"
+      }
+    }
+
+    Outbound = {
+      Allow443port = {
+        name                       = "Allow443"
+        priority                   = 100
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "*"
+        source_port_range          = "*"
+        destination_port_range     = "*"
+        source_address_prefix      = "*"
+        destination_address_prefix = "Internet"
+      }
+      Allow80port = {
+        name                       = "Allow80"
+        priority                   = 101
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "*"
+        source_port_range          = "*"
+        destination_port_range     = "*"
+        source_address_prefix      = "*"
+        destination_address_prefix = "Internet"
+      }
+      Allow_ssh_to_my_machine = {
+        name                       = "Allow_ssh_to_my_machine"
+        priority                   = 102
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "22"
+        source_address_prefix      = var.my_public_ip_address
+        destination_address_prefix = "*"
+      }
+    }
+  }
 }

--- a/modules/prod/security/main.tf
+++ b/modules/prod/security/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_network_security_group" "tarot_cloud_nsg" {
   resource_group_name = var.tarot_cloud_rg_name
 
   dynamic "security_rule" {
-    for_each = flatten([for group in var.security_rules : values(group)])
+    for_each = flatten([for group in local.security_rules : values(group)])
     content {
       name                       = security_rule.value.name
       priority                   = security_rule.value.priority

--- a/modules/prod/security/variables.tf
+++ b/modules/prod/security/variables.tf
@@ -7,76 +7,14 @@ variable "rg_location" {
 }
 
 variable "subnets" {
-  type = list(string)
+  type        = list(string)
   description = "Map of subnet IDs to attach NSGs"
-}
-
-variable "security_rules" {
-  type = map(map(object({
-    name                       = string
-    priority                   = number
-    direction                  = string
-    access                     = string
-    protocol                   = string
-    source_port_range          = string
-    destination_port_range     = string
-    source_address_prefix      = string
-    destination_address_prefix = string
-  })))
-
-  default = {
-    Inbound = {
-      Allow80port = {
-        name                       = "Allow80port"
-        priority                   = 100
-        direction                  = "Inbound"
-        access                     = "Allow"
-        protocol                   = "Tcp"
-        source_port_range          = "*"
-        destination_port_range     = "80"
-        source_address_prefix      = "*"
-        destination_address_prefix = "*"
-      }
-      Allow443port = {
-        name                       = "Allow443port"
-        priority                   = 101
-        direction                  = "Inbound"
-        access                     = "Allow"
-        protocol                   = "Tcp"
-        source_port_range          = "*"
-        destination_port_range     = "443"
-        source_address_prefix      = "*"
-        destination_address_prefix = "*"
-      }
-      Allow22port = {
-        name                       = "Allow22port"
-        priority                   = 102
-        direction                  = "Inbound"
-        access                     = "Allow"
-        protocol                   = "Tcp"
-        source_port_range          = "*"
-        destination_port_range     = "22"
-        source_address_prefix      = "*"
-        destination_address_prefix = "*"
-      }
-    }
-
-    Outbound = {
-      AllowAll = {
-        name                       = "AllowAll"
-        priority                   = 100
-        direction                  = "Outbound"
-        access                     = "Allow"
-        protocol                   = "*"
-        source_port_range          = "*"
-        destination_port_range     = "*"
-        source_address_prefix      = "*"
-        destination_address_prefix = "*"
-      }
-    }
-  }
 }
 
 variable "vnets" {
   type = list(string)
+}
+
+variable "my_public_ip_address" {
+  type = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,3 +3,9 @@ variable "ssh_public_key" {
   description = "Local SSH public key"
   sensitive   = true
 }
+
+variable "my_public_ip_address" {
+  type        = string
+  description = "Public IP address"
+  sensitive   = true
+}


### PR DESCRIPTION
Restrict SSH access to the Linux VM to the IP address specified in GitHub Secrets. Additionally, allow only HTTP (port 80) and HTTPS (port 443) access from the public internet. Variable "security_rules" was also moved to locals, becouse I couldn't reference the variable inside a default of variable and I wanted to automate passing my public ip address from github secrets automatically to a security rule. Add tfsec security scan with PR comments to GitHub Actions